### PR TITLE
fix: improve compatibility with mstsc.exe

### DIFF
--- a/XrdpUlalacaPrivate.cpp
+++ b/XrdpUlalacaPrivate.cpp
@@ -126,7 +126,53 @@ std::unique_ptr<std::vector<ULIPCRect>> XrdpUlalacaPrivate::createCopyRects(
     return std::move(blocks);
 }
 
+bool XrdpUlalacaPrivate::isRectOverlaps(const ULIPCRect &a, const ULIPCRect &b) {
+    int16_t a_x1 = a.x;
+    int16_t a_x2 = a.x + a.width;
+    int16_t a_y1 = a.y;
+    int16_t a_y2 = a.y + a.height;
+    int16_t b_x1 = b.x;
+    int16_t b_x2 = b.x + b.width;
+    int16_t b_y1 = b.y;
+    int16_t b_y2 = b.y + b.height;
+
+    return (
+            (a_x1 >= b_x1 && a_x1 <= b_x2 && a_y1 >= b_y1 && a_y1 <= b_y2) ||
+            (a_x2 >= b_x1 && a_x2 <= b_x2 && a_y1 >= b_y1 && a_y1 <= b_y2) ||
+            (a_x1 >= b_x1 && a_x1 <= b_x2 && a_y2 >= b_y1 && a_y2 <= b_y2) ||
+            (a_x2 >= b_x1 && a_x2 <= b_x2 && a_y2 >= b_y1 && a_y2 <= b_y2)
+    );
+}
+
+void XrdpUlalacaPrivate::mergeRect(ULIPCRect &a, const ULIPCRect &b) {
+    int16_t a_x1 = a.x;
+    int16_t a_x2 = a.x + a.width;
+    int16_t a_y1 = a.y;
+    int16_t a_y2 = a.y + a.height;
+    int16_t b_x1 = b.x;
+    int16_t b_x2 = b.x + b.width;
+    int16_t b_y1 = b.y;
+    int16_t b_y2 = b.y + b.height;
+
+    a.x = std::min(a_x1, b_x1);
+    a.y = std::min(a_y1, b_y1);
+    a.width  = std::max(a_x2, b_x2) - a.x;
+    a.height = std::max(a_y2, b_y2) - a.y;
+}
+
+std::vector<ULIPCRect> XrdpUlalacaPrivate::removeRectOverlap(const ULIPCRect &a, const ULIPCRect &b) {
+
+}
+
 void XrdpUlalacaPrivate::addDirtyRect(ULIPCRect &rect) {
+    for (auto &x: *_dirtyRects) {
+        if (isRectOverlaps(x, rect)) {
+            mergeRect(x, rect);
+            return;
+        }
+    }
+
+
     _dirtyRects->push_back(rect);
 }
 

--- a/XrdpUlalacaPrivate.cpp
+++ b/XrdpUlalacaPrivate.cpp
@@ -282,7 +282,7 @@ void XrdpUlalacaPrivate::updateThreadLoop() {
                         screenRect.width, screenRect.height,
                         (char *) image.get(),
                         screenRect.width, screenRect.height,
-                        0, (_frameId++ % INT32_MAX)
+                        0, 0
                 );
             } else {
                 _mod->server_paint_rects(

--- a/XrdpUlalacaPrivate.hpp
+++ b/XrdpUlalacaPrivate.hpp
@@ -45,6 +45,10 @@ public:
 
     constexpr static const int NO_ERROR = 0;
 
+    static bool isRectOverlaps(const ULIPCRect &a, const ULIPCRect &b);
+    static void mergeRect(ULIPCRect &a, const ULIPCRect &b);
+    static std::vector<ULIPCRect> removeRectOverlap(const ULIPCRect &a, const ULIPCRect &b);
+
     explicit XrdpUlalacaPrivate(XrdpUlalaca *mod);
     XrdpUlalacaPrivate(XrdpUlalacaPrivate &) = delete;
     ~XrdpUlalacaPrivate();


### PR DESCRIPTION
# DESCRIPTION
- **resolves #3**
- prevents overlap of drects / crects (calling `server_paint_rects()` with overlapped drects/crects causes protocol error)


# TODO
- clean-up code
- ~~native 1600x900 -> rdp 1280x720으로 연결하면 뻗는 문제 있음 확인 필요함~~