### PR TITLE
feature: send PROJECTION_HELLO message

### DIFF
--- a/ProjectorClient.hpp
+++ b/ProjectorClient.hpp
@@ -30,7 +30,8 @@ public:
 
     void start();
     void stop();
-    
+
+    void sendHello(const std::string &xrdpUlalacaVersion, const xrdp_client_info &clientInfo);
     void handleEvent(XrdpEvent &event);
     void setViewport(ULIPCRect rect);
     

--- a/XrdpUlalacaPrivate.cpp
+++ b/XrdpUlalacaPrivate.cpp
@@ -8,6 +8,8 @@
 
 #include "ProjectorClient.hpp"
 
+const std::string XrdpUlalacaPrivate::XRDP_ULALACA_VERSION = "0.1.1-git";
+
 XrdpUlalacaPrivate::XrdpUlalacaPrivate(XrdpUlalaca *mod):
         _mod(mod),
         _error(0),
@@ -65,6 +67,9 @@ void XrdpUlalacaPrivate::attachToSession(std::string sessionPath) {
     );
 
     _projectorClient->start();
+
+    _projectorClient->sendHello(XRDP_ULALACA_VERSION, _clientInfo);
+
     _isUpdateThreadRunning = true;
     _updateThread = std::make_unique<std::thread>(
         &XrdpUlalacaPrivate::updateThreadLoop, this

--- a/XrdpUlalacaPrivate.hpp
+++ b/XrdpUlalacaPrivate.hpp
@@ -41,6 +41,9 @@ struct ScreenUpdate {
 
 class XrdpUlalacaPrivate: public ProjectionTarget {
 public:
+    // FIXME: is there TWO VERSION FIELDS??? (see ulalaca.hpp)
+    static const std::string XRDP_ULALACA_VERSION;
+
     constexpr static const int RECT_SIZE_BYPASS_CREATE = 0;
 
     constexpr static const int NO_ERROR = 0;

--- a/messages/_global.h
+++ b/messages/_global.h
@@ -3,6 +3,9 @@
 
 #include <stdint.h>
 
+#define ULALACA_IPC_PROTO_VERSION 0x1000
+#define ULALACA_IPC_PROTO_VERSION_REVISION 0x0000
+
 /**
  * FIXME: naming
  */

--- a/messages/projector.h
+++ b/messages/projector.h
@@ -19,9 +19,14 @@ static const uint16_t TYPE_EVENT_MOUSE_WHEEL  = 0x0323;
 
 static const uint16_t TYPE_PROJECTION_START        = 0x0401;
 static const uint16_t TYPE_PROJECTION_STOP         = 0x0402;
+static const uint16_t TYPE_PROJECTION_HELLO        = 0x0411;
 
 static const uint16_t TYPE_PROJECTION_SET_VIEWPORT = 0x0421;
 
+/* constants: message type (client <-> server) */
+static const uint16_t TYPE_STREAM_DATA    = 0x0111;
+static const uint16_t TYPE_STREAM_NOTIFY  = 0x0112;
+static const uint16_t TYPE_STREAM_REQUEST = 0x0113;
 
 /* constants: Screen update notification */
 static const uint8_t SCREEN_UPDATE_NOTIFY_TYPE_ENTIRE_SCREEN = 0;
@@ -52,6 +57,51 @@ static const uint8_t MOUSE_EVENT_TYPE_DOWN = 2;
 static const uint8_t MOUSE_EVENT_BUTTON_LEFT = 0;
 static const uint8_t MOUSE_EVENT_BUTTON_RIGHT = 1;
 static const uint8_t MOUSE_EVENT_BUTTON_MIDDLE = 2;
+
+/* constants: Stream-related */
+static const uint8_t STREAM_TYPE_NULL      = 0;
+static const uint8_t STREAM_TYPE_AUDIO     = 1;
+static const uint8_t STREAM_TYPE_VIDEO     = 2;
+static const uint8_t STREAM_TYPE_CLIPBOARD = 3;
+/** drag & drop */
+static const uint8_t STREAM_TYPE_FILE      = 4;
+static const uint8_t STREAM_TYPE_PRINT     = 5;
+
+/**
+ * indicates the stream will start.
+ */
+static const uint8_t STREAM_NOTIFY_TYPE_START = 0;
+/**
+ * indicates the stream has ended.
+ */
+static const uint8_t STREAM_NOTIFY_TYPE_STOP  = 1;
+/**
+ * indicates an error occurred during streaming, or the request cannot be fulfilled.
+ */
+static const uint8_t STREAM_NOTIFY_TYPE_ERROR = 2;
+/**
+ * indicates the client received the data.
+ */
+static const uint8_t STREAM_NOTIFY_TYPE_ACK = 3;
+
+static const uint8_t STREAM_DATA_FLAG_NONE   = 0b00000000;
+/** marks the end of stream. */
+static const uint8_t STREAM_DATA_FLAG_EOS    = 0b00000001;
+/**
+ * ignores time-ordered queue. (data will be processed immediately / previous data will be discarded)
+ */
+static const uint8_t STREAM_DATA_FLAG_URGENT = 0b00000010;
+
+
+/* constants: codec enums for PROJECTION_HELLO */
+static const uint8_t PROJECTION_HELLO_CODEC_NONE    = 0;
+static const uint8_t PROJECTION_HELLO_CODEC_RFX     = 1;
+static const uint8_t PROJECTION_HELLO_CODEC_H264    = 2;
+static const uint8_t PROJECTION_HELLO_CODEC_NSCODEC = 3;
+
+/* constants: flags for PROJECTION_HELLO */
+static const uint8_t PROJECTION_HELLO_FLAG_NONE = 0b00000000;
+
 
 /* message definition: server -> client */
 struct ULIPCScreenUpdateNotify {
@@ -107,10 +157,67 @@ struct ULIPCProjectionStop {
     uint16_t flags;
 } MARK_AS_PACKED_STRUCT;
 
+struct ULIPCProjectionHello {
+    uint8_t xrdpUlalacaVersion[32];
+
+    uint8_t clientAddress[46];
+    uint8_t clientDescription[256];
+
+    uint32_t clientOSMajor;
+    uint32_t clientOSMinor;
+
+    uint8_t program[512];
+
+    uint8_t codec;
+
+    uint16_t flags;
+} MARK_AS_PACKED_STRUCT;
+
 struct ULIPCProjectionSetViewport {
     uint8_t monitorId;
     uint16_t width;
     uint16_t height;
+
+    uint16_t flags;
+} MARK_AS_PACKED_STRUCT;
+
+struct ULIPCStreamData {
+    uint8_t resourceType;
+    uint64_t resourceId;
+
+    uint64_t timestamp;
+    uint32_t length;
+
+    uint32_t crc;
+    uint8_t flags;
+} MARK_AS_PACKED_STRUCT;
+
+union ULIPCStreamNotifyData {
+    /**
+     * dummy data for padding.
+     */
+    struct {
+        uint8_t __pad__[32];
+    } MARK_AS_PACKED_STRUCT __pad__;
+
+    struct {
+        uint8_t reason;
+    } MARK_AS_PACKED_STRUCT error;
+} MARK_AS_PACKED_STRUCT;
+
+struct ULIPCStreamNotify {
+    uint8_t type;
+    uint8_t resourceType;
+    uint64_t resourceId;
+
+    union ULIPCStreamNotifyData data;
+
+    uint16_t flags;
+} MARK_AS_PACKED_STRUCT;
+
+struct ULIPCStreamRequest {
+    uint8_t resourceType;
+    uint64_t resourceId;
 
     uint16_t flags;
 } MARK_AS_PACKED_STRUCT;


### PR DESCRIPTION
# CHANGES
- IPC: `PROJECTION_HELLO` message that announces remote client's IP address, ..etc will be sent after connection has established.
- IPC: added experimental message definitions of 'ULIPCStream*' to provide transports for audio, clipboard, ...etc between ulalaca and xrdp.

- this version of XrdpUlalaca may have compatibility issues with currently released version of sessionprojector.app (0.0.0-test)