### PR TITLE
Include cassert in IPCConnection.hpp

### DIFF
--- a/IPCConnection.hpp
+++ b/IPCConnection.hpp
@@ -9,6 +9,7 @@
 #include <thread>
 #include <queue>
 #include <future>
+#include <cassert>
 
 #include "UnixSocket.hpp"
 


### PR DESCRIPTION
On macOS Sonoma, compilation failed with:

```
In file included from SessionBrokerClient.cpp:5:
In file included from ./SessionBrokerClient.hpp:10:
./IPCConnection.hpp:56:9: error: use of undeclared identifier 'assert'
        assert(size != 0);
        ^
In file included from ProjectorClient.cpp:20:
In file included from ./ProjectorClient.hpp:15:
./IPCConnection.hpp:56:9: error: use of undeclared identifier 'assert'
        assert(size != 0);
        ^
1 error generated.
make[2]: *** [SessionBrokerClient.lo] Error 1
make[2]: *** Waiting for unfinished jobs....
1 error generated.
make[2]: *** [ProjectorClient.lo] Error 1
make[1]: *** [all-recursive] Error 1
make: *** [all] Error 2
```

Include cassert in IPCConnection.hpp solve this problem