### PR TITLE
refactor: move render-related codes to `ulalaca::ULSurface`

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,6 +32,8 @@ libulalaca_la_SOURCES = \
   ProjectorClient.hpp \
   ProjectorClient.cpp \
   KeycodeMap.cpp \
+  ULSurface.cpp \
+  ULSurface.hpp \
   XrdpUlalacaPrivate.cpp \
   XrdpUlalacaPrivate.xrdpmodule.cpp \
   XrdpUlalacaPrivate.hpp \

--- a/ULSurface.cpp
+++ b/ULSurface.cpp
@@ -333,6 +333,9 @@ namespace ulalaca {
             0
         );
 
+
+        _pendingRects.clear();
+
         return true;
     }
 

--- a/ULSurface.cpp
+++ b/ULSurface.cpp
@@ -202,10 +202,12 @@ namespace ulalaca {
 
         _crectSize(RECT_SIZE_BYPASS_CREATE),
 
-        _frameId(1),
+        _frameId(0),
         _ackFrameId(0),
 
-        _updateThreadId()
+        _updateThreadId(),
+
+        __HACK__mstsc_workaround(true)
     {
 
     }
@@ -271,6 +273,22 @@ namespace ulalaca {
         }
 
         if (rects.empty()) {
+            return;
+        }
+
+        if (__HACK__mstsc_workaround) {
+            // we should draw entire screen at least once to make mstsc.exe happy
+            __HACK__mstsc_workaround = false;
+
+            _mod->server_paint_rect(
+                    _mod,
+                    0, 0,
+                    _width, _height,
+                    (char *) bitmap,
+                    bitmapWidth, bitmapHeight,
+                    0, (_frameId++ % INT32_MAX)
+            );
+
             return;
         }
 

--- a/ULSurface.cpp
+++ b/ULSurface.cpp
@@ -340,10 +340,12 @@ namespace ulalaca {
     }
 
     bool ULSurface::shouldDropFrame(const ULSurfaceTransaction &transaction) const {
+        constexpr static const int MAX_FRAME_DELAY = 2;
+
         int fdelta = std::abs(_frameId - _ackFrameId);
 
         return (
-            fdelta > 1
+            fdelta > MAX_FRAME_DELAY
         );
     }
 

--- a/ULSurface.cpp
+++ b/ULSurface.cpp
@@ -337,17 +337,10 @@ namespace ulalaca {
     }
 
     bool ULSurface::shouldDropFrame(const ULSurfaceTransaction &transaction) const {
-        constexpr static const double tdeltaThreshold = 1.0 / 20.0;
-
         int fdelta = std::abs(_frameId - _ackFrameId);
 
-        auto now = std::chrono::steady_clock::now();
-        double timestamp = std::chrono::duration<double>(now.time_since_epoch()).count();
-        double tdelta = timestamp - transaction.timestamp();
-
         return (
-            fdelta > 1 ||
-            tdelta > tdeltaThreshold
+            fdelta > 1
         );
     }
 

--- a/ULSurface.cpp
+++ b/ULSurface.cpp
@@ -163,6 +163,14 @@ namespace ulalaca {
 
     }
 
+    int ULSurface::width() const {
+        return _width;
+    }
+
+    int ULSurface::height() const {
+        return _height;
+    }
+
     void ULSurface::setSize(int width, int height) {
         _width = width;
         _height = height;

--- a/ULSurface.cpp
+++ b/ULSurface.cpp
@@ -1,0 +1,252 @@
+//
+// Created by Gyuhwan Park on 10/28/23.
+//
+
+#include "ULSurface.hpp"
+
+namespace ulalaca {
+    ULSurfaceException::ULSurfaceException(const std::string &message):
+        _message(message)
+    {
+
+    }
+
+    const std::string &ULSurfaceException::getMessage() const {
+        return _message;
+    }
+
+    const char *ULSurfaceException::what() const noexcept {
+        return _message.c_str();
+    }
+
+
+    bool ULSurface::isRectOverlaps(const ULIPCRect &a, const ULIPCRect &b) {
+        int16_t a_x1 = a.x;
+        int16_t a_x2 = a.x + a.width;
+        int16_t a_y1 = a.y;
+        int16_t a_y2 = a.y + a.height;
+        int16_t b_x1 = b.x;
+        int16_t b_x2 = b.x + b.width;
+        int16_t b_y1 = b.y;
+        int16_t b_y2 = b.y + b.height;
+
+        return (
+                (a_x1 >= b_x1 && a_x1 <= b_x2 && a_y1 >= b_y1 && a_y1 <= b_y2) ||
+                (a_x2 >= b_x1 && a_x2 <= b_x2 && a_y1 >= b_y1 && a_y1 <= b_y2) ||
+                (a_x1 >= b_x1 && a_x1 <= b_x2 && a_y2 >= b_y1 && a_y2 <= b_y2) ||
+                (a_x2 >= b_x1 && a_x2 <= b_x2 && a_y2 >= b_y1 && a_y2 <= b_y2)
+        );
+    }
+
+    void ULSurface::mergeRect(ULIPCRect &a, const ULIPCRect &b) {
+        int16_t a_x1 = a.x;
+        int16_t a_x2 = a.x + a.width;
+        int16_t a_y1 = a.y;
+        int16_t a_y2 = a.y + a.height;
+        int16_t b_x1 = b.x;
+        int16_t b_x2 = b.x + b.width;
+        int16_t b_y1 = b.y;
+        int16_t b_y2 = b.y + b.height;
+
+        a.x = std::min(a_x1, b_x1);
+        a.y = std::min(a_y1, b_y1);
+        a.width  = std::max(a_x2, b_x2) - a.x;
+        a.height = std::max(a_y2, b_y2) - a.y;
+    }
+
+    std::vector<ULIPCRect> ULSurface::createCopyRects(
+            const std::vector<ULIPCRect> &drects,
+            int rectSize,
+            int surfaceWidth, int surfaceHeight
+    ) {
+        if (rectSize == RECT_SIZE_BYPASS_CREATE) {
+            return drects;
+        }
+
+        std::vector<ULIPCRect> blocks;
+
+        blocks.reserve((surfaceWidth * surfaceHeight) / (rectSize * rectSize));
+
+        /*
+         * sorry, i'm not good at math. XDD
+         */
+
+        int mapWidth  = std::ceil((float) surfaceWidth / (float) rectSize);
+        int mapHeight = std::ceil((float) surfaceHeight / (float) rectSize);
+        int mapSize = mapWidth * mapHeight;
+        std::unique_ptr<uint8_t> rectMap(new uint8_t[mapSize]);
+        memset(rectMap.get(), 0x00, mapSize);
+
+        for (auto &dirtyRect : drects) {
+            if (surfaceWidth <= dirtyRect.x ||
+                surfaceHeight <= dirtyRect.y) {
+                continue;
+            }
+
+            int mapX1 = (int) std::floor((float) dirtyRect.x / rectSize);
+            int mapY1 = (int) std::floor((float) dirtyRect.y / rectSize);
+            int mapX2 = std::min(
+                    (int) std::ceil((float) (dirtyRect.x + dirtyRect.width) / rectSize),
+                    mapWidth
+            ) - 1;
+            int mapY2 = std::min(
+                    (int) std::ceil((float) (dirtyRect.y + dirtyRect.height) / rectSize),
+                    mapHeight
+            ) - 1;
+
+            for (int y = mapY1; y <= mapY2; y++) {
+                for (int x = mapX1; x <= mapX2; x++) {
+                    rectMap.get()[(y * mapWidth) + x] = 0x01;
+                }
+            }
+        }
+
+        for (int y = 0; y < mapHeight; y++) {
+            for (int x = 0; x < mapWidth; x++) {
+                if (rectMap.get()[(y * mapWidth) + x] == 0x01) {
+                    int rectX = x * rectSize;
+                    int rectY = y * rectSize;
+
+                    blocks.emplace_back(ULIPCRect{(short) rectX, (short) rectY, (short) rectSize, (short) rectSize});
+                }
+            }
+        }
+
+        return std::move(blocks);
+    }
+
+    std::vector<ULIPCRect> ULSurface::cleanupRects(const std::vector<ULIPCRect> &rects) {
+        std::vector<ULIPCRect> result;
+        result.reserve(rects.size());
+
+        for (const ULIPCRect &rect: rects) {
+            bool merged = false;
+
+            for (ULIPCRect &resultRect: result) {
+                if (isRectOverlaps(resultRect, rect)) {
+                    mergeRect(resultRect, rect);
+                    merged = true;
+                    break;
+                }
+            }
+
+            if (!merged) {
+                result.push_back(rect);
+            }
+        }
+
+        return std::move(result);
+    }
+
+    std::unique_ptr<short> ULSurface::allocateRectArray(const std::vector<ULIPCRect> &rects) {
+        static_assert(sizeof(ULIPCRect) == (sizeof(short) * 4));
+
+        std::unique_ptr<short> result(new short[rects.size() * 4]);
+        memcpy(result.get(), rects.data(), sizeof(ULIPCRect) * rects.size());
+
+        return std::move(result);
+    }
+
+    ULSurface::ULSurface(XrdpUlalaca *mod):
+        _mod(mod),
+
+        _width(640),
+        _height(480),
+
+        _crectSize(RECT_SIZE_BYPASS_CREATE),
+
+        _frameId(1),
+        _ackFrameId(0),
+
+        _updateThreadId()
+    {
+
+    }
+
+    void ULSurface::setSize(int width, int height) {
+        _width = width;
+        _height = height;
+    }
+
+    void ULSurface::setCRectSize(int crectSize) {
+        _crectSize = crectSize;
+    }
+
+    void ULSurface::setAckFrameId(int ackFrameId) {
+        _ackFrameId = ackFrameId;
+    }
+
+    bool ULSurface::canUpdate() const {
+        return _updateThreadId == std::thread::id();
+    }
+
+    void ULSurface::beginUpdate() {
+        if (_updateThreadId != std::thread::id()) {
+            throw ULSurfaceException("another thread is updating the surface");
+        }
+
+        _updateThreadId = std::this_thread::get_id();
+        _mod->server_begin_update(_mod);
+    }
+
+    void ULSurface::endUpdate() {
+        if (_updateThreadId == std::thread::id()) {
+            LOG(LOG_LEVEL_WARNING, "endUpdate() called without beginUpdate()");
+            return;
+        }
+
+        _mod->server_end_update(_mod);
+        _updateThreadId = std::thread::id();
+    }
+
+    void ULSurface::drawBitmap(int x, int y, int width, int height,
+                               const uint8_t *bitmap, size_t bitmapSize,
+                               int bitmapWidth, int bitmapHeight, int flags) {
+        std::vector rects {
+            ULIPCRect { (short) x, (short) y, (short) width, (short) height }
+        };
+
+        this->drawBitmap(rects, bitmap, bitmapSize, bitmapWidth, bitmapHeight, flags);
+    }
+
+    void ULSurface::drawBitmap(const std::vector<ULIPCRect> &rects, const uint8_t *bitmap, size_t bitmapSize,
+                               int bitmapWidth, int bitmapHeight, int flags) {
+        if (_updateThreadId != std::this_thread::get_id()) {
+            throw ULSurfaceException("this thread is not holding the update lock");
+        }
+
+        if (rects.empty()) {
+            return;
+        }
+
+        const std::vector<ULIPCRect> &cleanedRects = cleanupRects(rects);
+        const std::vector<ULIPCRect> &copyRects = createCopyRects(cleanedRects, _crectSize, _width, _height);
+
+        std::unique_ptr<short> drects = std::move(allocateRectArray(cleanedRects));
+        std::unique_ptr<short> crects = std::move(allocateRectArray(copyRects));
+
+        if (flags & FLAG_FORCE_RAW_BITMAP) {
+            for (const auto &rect: cleanedRects) {
+                _mod->server_paint_rect(
+                    _mod,
+                    rect.x, rect.y,
+                    rect.width, rect.height,
+                    (char *) bitmap,
+                    bitmapWidth, bitmapHeight,
+                    0, (_frameId++ % INT32_MAX)
+                );
+            }
+        } else {
+            _mod->server_paint_rects(
+                _mod,
+                cleanedRects.size(), drects.get(),
+                copyRects.size(), crects.get(),
+                (char *) bitmap,
+                bitmapWidth, bitmapHeight,
+                0, (_frameId++ % INT32_MAX)
+            );
+        }
+    }
+
+
+}

--- a/ULSurface.hpp
+++ b/ULSurface.hpp
@@ -1,0 +1,89 @@
+//
+// Created by Gyuhwan Park on 10/28/23.
+//
+
+#ifndef XRDP_TUMOD_ULSURFACE_HPP
+#define XRDP_TUMOD_ULSURFACE_HPP
+
+#include "ulalaca.hpp"
+
+namespace ulalaca {
+    class ULSurfaceException: public std::exception {
+    public:
+        explicit ULSurfaceException(const std::string &message);
+        ~ULSurfaceException() override = default;
+
+        const std::string &getMessage() const;
+
+        const char* what() const noexcept override;
+
+    private:
+        std::string _message;
+    };
+
+
+    class ULSurface {
+    public:
+        constexpr static const int RECT_SIZE_BYPASS_CREATE = 0;
+
+        static bool isRectOverlaps(const ULIPCRect &a, const ULIPCRect &b);
+        static void mergeRect(ULIPCRect &a, const ULIPCRect &b);
+
+        static std::vector<ULIPCRect> cleanupRects(const std::vector<ULIPCRect> &rects);
+        static std::vector<ULIPCRect> createCopyRects(const std::vector<ULIPCRect> &drects,
+                                                      int rectSize, int surfaceWidth, int surfaceHeight);
+
+        static std::unique_ptr<short>allocateRectArray(const std::vector<ULIPCRect> &rects);
+
+
+
+        /**
+         * @brief force to use server_paint_rect() instead of server_paint_rects()
+         */
+        static const int FLAG_FORCE_RAW_BITMAP = 0x01;
+
+        explicit ULSurface(XrdpUlalaca *mod);
+
+        void setSize(int width, int height);
+        void setCRectSize(int crectSize);
+
+        void setAckFrameId(int ackFrameId);
+
+        [[nodiscard]]
+        bool canUpdate() const;
+
+        /**
+         * @brief notifies that the surface will be updated to the xrdp server.
+         */
+        void beginUpdate();
+
+        /**
+         * @brief notifies that the surface has been updated to the xrdp server.
+         */
+        void endUpdate();
+
+        void drawBitmap(int x, int y, int width, int height,
+                        const uint8_t *bitmap, size_t bitmapSize,
+                        int bitmapWidth, int bitmapHeight,
+                        int flags);
+        void drawBitmap(const std::vector<ULIPCRect> &rects,
+                        const uint8_t *bitmap, size_t bitmapSize,
+                        int bitmapWidth, int bitmapHeight,
+                        int flags);
+
+    private:
+        XrdpUlalaca *_mod;
+
+        int _width;
+        int _height;
+
+        int _crectSize;
+
+        int _frameId;
+        int _ackFrameId;
+
+        std::thread::id _updateThreadId;
+    };
+}
+
+#endif //XRDP_TUMOD_ULSURFACE_HPP

--- a/ULSurface.hpp
+++ b/ULSurface.hpp
@@ -136,6 +136,8 @@ namespace ulalaca {
         std::vector<ULIPCRect> _pendingRects;
 
         std::thread::id _updateThreadId;
+
+        bool __HACK__mstsc_workaround;
     };
 }
 

--- a/ULSurface.hpp
+++ b/ULSurface.hpp
@@ -44,6 +44,9 @@ namespace ulalaca {
 
         explicit ULSurface(XrdpUlalaca *mod);
 
+        int width() const;
+        int height() const;
+
         void setSize(int width, int height);
         void setCRectSize(int crectSize);
 

--- a/XrdpUlalacaPrivate.hpp
+++ b/XrdpUlalacaPrivate.hpp
@@ -48,18 +48,14 @@ public:
     // FIXME: is there TWO VERSION FIELDS??? (see ulalaca.hpp)
     static const std::string XRDP_ULALACA_VERSION;
 
-    constexpr static const int RECT_SIZE_BYPASS_CREATE = 0;
 
     constexpr static const int NO_ERROR = 0;
-
-    static bool isRectOverlaps(const ULIPCRect &a, const ULIPCRect &b);
-    static void mergeRect(ULIPCRect &a, const ULIPCRect &b);
-    static std::vector<ULIPCRect> removeRectOverlap(const ULIPCRect &a, const ULIPCRect &b);
 
     explicit XrdpUlalacaPrivate(XrdpUlalaca *mod);
     XrdpUlalacaPrivate(XrdpUlalacaPrivate &) = delete;
     ~XrdpUlalacaPrivate();
 
+public:
     /* lib_mod_* */
     int libModStart(int width, int height, int bpp);
     int libModConnect();
@@ -78,6 +74,7 @@ public:
     int libModServerMonitorFullInvalidate(int width, int height);
     int libModServerVersionMessage();
 
+public:
     /* utility methods / lib_server_* wrappers */
     void serverMessage(const char *message, int code);
 
@@ -140,7 +137,6 @@ private:
     std::unique_ptr<ulalaca::ULSurface> _surface;
 
     std::queue<ScreenUpdate> _updateQueue;
-
 };
 
 #endif

--- a/XrdpUlalacaPrivate.hpp
+++ b/XrdpUlalacaPrivate.hpp
@@ -39,6 +39,10 @@ struct ScreenUpdate {
     std::shared_ptr<std::vector<ULIPCRect>> dirtyRects;
 };
 
+namespace ulalaca {
+    class ULSurface;
+}
+
 class XrdpUlalacaPrivate: public ProjectionTarget {
 public:
     // FIXME: is there TWO VERSION FIELDS??? (see ulalaca.hpp)
@@ -82,10 +86,7 @@ public:
      */
     void attachToSession(std::string sessionPath);
 
-
-    /* paint related */
     int decideCopyRectSize() const;
-    std::shared_ptr<std::vector<ULIPCRect>> createCopyRects(std::vector<ULIPCRect> &dirtyRects, int rectSize) const;
 
     void addDirtyRect(ULIPCRect &rect) override;
     void commitUpdate(const uint8_t *image, size_t size, int32_t width, int32_t height) override;
@@ -108,6 +109,7 @@ public:
 
 private:
     XrdpUlalaca *_mod;
+
     int _error = 0;
     bool _isUpdateThreadRunning;
 
@@ -115,9 +117,6 @@ private:
     std::vector<ULIPCRect> _screenLayouts;
 
     int _bpp;
-
-    std::atomic_int64_t _frameId;
-    std::atomic_int64_t _ackFrameId;
 
     std::string _username;
     std::string _password;
@@ -129,6 +128,7 @@ private:
     int _encodingsMask;
     xrdp_client_info _clientInfo;
 
+
     std::unique_ptr<UnixSocket> _socket;
     std::unique_ptr<ProjectorClient> _projectorClient;
     std::unique_ptr<std::thread> _updateThread;
@@ -137,6 +137,7 @@ private:
     std::mutex _commitUpdateLock;
 
     std::shared_ptr<std::vector<ULIPCRect>> _dirtyRects;
+    std::unique_ptr<ulalaca::ULSurface> _surface;
 
     std::queue<ScreenUpdate> _updateQueue;
 

--- a/XrdpUlalacaPrivate.xrdpmodule.cpp
+++ b/XrdpUlalacaPrivate.xrdpmodule.cpp
@@ -2,11 +2,13 @@
 
 #include "XrdpUlalacaPrivate.hpp"
 
+#include "messages/broker.h"
+
 #include "ulalaca.hpp"
 #include "SessionBrokerClient.hpp"
 #include "ProjectorClient.hpp"
 
-#include "messages/broker.h"
+#include "ULSurface.hpp"
 
 int XrdpUlalacaPrivate::libModStart(int width, int height, int bpp) {
     // #517eb9
@@ -14,19 +16,17 @@ int XrdpUlalacaPrivate::libModStart(int width, int height, int bpp) {
 
     setSessionSize(width, height);
 
-    _mod->server_begin_update(_mod);
-    _mod->server_set_fgcolor(_mod, (int) BACKGROUND_COLOR);
-    _mod->server_fill_rect(_mod, 0, 0, width, height);
-    _mod->server_end_update(_mod);
+    _surface->beginUpdate();
+    _surface->setForegroundColor(BACKGROUND_COLOR);
+    _surface->fillRect(0, 0, width, height);
+    _surface->endUpdate();
 
-    /*
-    if (!isBPPSupported(bpp)) {
-        return 1;
+    if (bpp != 32) {
+        LOG(LOG_LEVEL_WARNING, "client bpp %d is not supported, but using it anyway", bpp);
     }
-     */
 
     _bpp = bpp;
-    // _this->updateBpp(bpp);
+
 
     return 0;
 }
@@ -169,9 +169,7 @@ int XrdpUlalacaPrivate::libModCheckWaitObjs() {
 }
 
 int XrdpUlalacaPrivate::libModFrameAck(int flags, int frameId) {
-    LOG(LOG_LEVEL_TRACE, "lib_mod_frame_ack() called: %d", frameId);
-    _ackFrameId = frameId;
-
+    _surface->setAckFrameId(frameId);
     return 0;
 }
 

--- a/XrdpUlalacaPrivate.xrdpmodule.cpp
+++ b/XrdpUlalacaPrivate.xrdpmodule.cpp
@@ -158,6 +158,8 @@ int XrdpUlalacaPrivate::libModGetWaitObjs(tbus *readObjs, int *rcount, tbus *wri
     }
 
     readObjs[(*rcount)++] = _projectorClient->descriptor();
+    readObjs[(*rcount)++] = _updateWaitObj;
+
     writeObjs[(*wcount)++] = _projectorClient->descriptor();
 
     return 0;
@@ -165,6 +167,10 @@ int XrdpUlalacaPrivate::libModGetWaitObjs(tbus *readObjs, int *rcount, tbus *wri
 
 int XrdpUlalacaPrivate::libModCheckWaitObjs() {
     // TODO: move ipcConnection.read()/write() to here..?
+    if (_error == 1) {
+        return 1;
+    }
+
     return 0;
 }
 
@@ -182,7 +188,6 @@ int XrdpUlalacaPrivate::libModServerMonitorResize(int width, int height) {
 }
 
 int XrdpUlalacaPrivate::libModServerMonitorFullInvalidate(int width, int height) {
-    _fullInvalidate = true;
     return 0;
 }
 


### PR DESCRIPTION
# SUMMARY
- server_draw_rects() 만 사용하도록 함 -> 이전보다 안정성이 향상된 것 같은 느낌!

# TODO
- thread id 체크하는거 나머지 구현해야됨

## COMPATIBILITY
- iOS에서 크래시 안남
- **Windows에서 크래시 나는지 체크 필요** -> 조건부로 크래시 남