### PR TITLE
[WIP] fix(ipc): reimplement I/O loop

### DIFF
--- a/IPCConnection.cpp
+++ b/IPCConnection.cpp
@@ -66,7 +66,7 @@ namespace ulalaca::ipc {
     }
 
     IPCDataBlockPtr IPCConnection::readBlock(size_t size) {
-        if (size < 0) {
+        if (size < 0 || !_isGood) {
             return nullptr;
         }
 
@@ -92,6 +92,10 @@ namespace ulalaca::ipc {
     void IPCConnection::writeBlock(const void *pointer, size_t size) {
         assert(pointer != nullptr);
         assert(size > 0);
+
+        if (!_isGood) {
+            return;
+        }
 
         auto writeTask = std::make_shared<IPCWriteTask>(IPCWriteTask {
                 size,

--- a/IPCConnection.cpp
+++ b/IPCConnection.cpp
@@ -18,164 +18,99 @@ extern "C" {
 
 #include "IPCConnection.hpp"
 
-IPCConnection::IPCConnection(std::shared_ptr<UnixSocket> socket):
-    _socket(std::move(socket)),
-    _isWorkerTerminated(false),
+namespace ulalaca::ipc {
 
-    _workerThread(),
-    _messageId(0),
-    _ackId(0),
-    _isGood(true)
-{
+    IPCConnection::IPCConnection(std::shared_ptr<UnixSocket> socket) :
+            _socket(std::move(socket)),
+            _isWorkerTerminated(false),
 
-}
+            _workerThread(),
+            _messageId(0),
+            _ackId(0),
+            _isGood(true) {
 
-IPCConnection::IPCConnection(const std::string &socketPath):
-    IPCConnection(std::make_shared<UnixSocket>(socketPath))
-{
-
-}
-
-FD IPCConnection::descriptor() {
-    return _socket->descriptor();
-}
-
-void IPCConnection::connect() {
-    _socket->connect();
-
-    // enable non-blocking io
-    auto flags = _socket->fcntl(F_GETFL, 0);
-    if (_socket->fcntl(F_SETFL, flags | O_NONBLOCK)) {
-        throw SystemCallException(errno, "fcntl");
     }
 
-    _workerThread = std::thread(&IPCConnection::workerLoop, this);
-}
+    IPCConnection::IPCConnection(const std::string &socketPath) :
+            IPCConnection(std::make_shared<UnixSocket>(socketPath)) {
 
-void IPCConnection::disconnect() {
-    _isWorkerTerminated = true;
-    
-    if (_workerThread.joinable()) {
-        _workerThread.join();
     }
-    _socket->close();
-}
 
-bool IPCConnection::isGood() const {
-    return _isGood;
-}
-
-std::unique_ptr<ULIPCHeader, IPCConnection::MallocFreeDeleter> IPCConnection::nextHeader() {
-    return std::move(read<ULIPCHeader>(sizeof(ULIPCHeader)));
-}
-
-void IPCConnection::write(const void *pointer, size_t size) {
-    assert(pointer != nullptr);
-    assert(size > 0);
-    
-    std::unique_ptr<uint8_t, MallocFreeDeleter> data(
-        (uint8_t *) malloc(size),
-        free
-    );
-    
-    std::memcpy(data.get(), pointer, size);
-    
-    {
-        std::scoped_lock<std::mutex> scopedWriteTasksLock(_writeTasksLock);
-        _writeTasks.emplace(size, std::move(data));
+    FD IPCConnection::descriptor() {
+        return _socket->descriptor();
     }
-}
 
-void IPCConnection::workerLoop() {
-    const size_t MAX_READ_SIZE = 8192;
+    void IPCConnection::connect() {
+        _socket->connect();
 
-    size_t readPos = 0;
-    std::unique_ptr<uint8_t> readBuffer;
-
-    _isGood = true;
-
-    while (!_isWorkerTerminated) {
-        auto pollFd = _socket->poll(POLLIN | POLLOUT, -1);
-
-        bool canRead = (pollFd.revents & POLLIN) > 0;
-        bool canWrite = (pollFd.revents & POLLOUT) > 0;
-
-        if (canWrite && !_writeTasks.empty()) {
-            _writeTasksLock.lock();
-            auto writeTask = std::move(_writeTasks.front());
-            _writeTasks.pop();
-            _writeTasksLock.unlock();
-
-
-            if (_socket->write(writeTask.second.get(), writeTask.first) < 0) {
-                if (errno == EAGAIN) {
-                    continue;
-                }
-
-                LOG(LOG_LEVEL_ERROR, "write() failed (errno=%d)", errno);
-                continue;
-            }
+        // enable non-blocking io
+        auto flags = _socket->fcntl(F_GETFL, 0);
+        if (_socket->fcntl(F_SETFL, flags | O_NONBLOCK)) {
+            throw SystemCallException(errno, "fcntl");
         }
 
-        if (canRead && !_readTasks.empty()) {
-            auto &readTask = _readTasks.front();
+        _workerThread = std::thread(&IPCConnection::workerLoop, this);
+    }
 
-            auto &contentLength = readTask.first;
-            auto &promise = readTask.second;
+    void IPCConnection::disconnect() {
+        _isWorkerTerminated = true;
 
-            if (readBuffer == nullptr) {
-                readPos = 0;
-                readBuffer = std::unique_ptr<uint8_t>(new uint8_t[contentLength]);
-            }
+        if (_workerThread.joinable()) {
+            _workerThread.join();
+        }
+        _socket->close();
+    }
 
-            int readForBytes = std::min(
-                (size_t) MAX_READ_SIZE,
-                contentLength - readPos
-            );
+    bool IPCConnection::isGood() const {
+        return _isGood;
+    }
 
-            size_t retval = _socket->read(readBuffer.get() + readPos, readForBytes);
-
-            if (retval < 0) {
-                if (errno == EAGAIN) {
-                    continue;
-                } else {
-                    throw SystemCallException(errno, "read");
-                }
-            }
-
-            if (_isGood && retval <= 0) {
-                break;
-            }
-
-            readPos += retval;
-
-            if (readPos >= contentLength) {
-                promise->set_value(std::move(readBuffer));
-                {
-                    std::scoped_lock<std::mutex> scopedReadTasksLock(_readTasksLock);
-                    _readTasks.pop();
-                }
-
-                readBuffer = nullptr;
-                readPos = 0;
-            }
+    IPCDataBlockPtr IPCConnection::readBlock(size_t size) {
+        if (size < 0) {
+            return nullptr;
         }
 
-        if (pollFd.revents & POLLHUP) {
-            LOG(LOG_LEVEL_WARNING, "POLLHUP bit set");
-            _isGood = false;
+        auto readTask = std::make_shared<IPCReadTask>(IPCReadTask {
+            size,
+            std::make_shared<IPCReadPromise>(),
 
-            if (_readTasks.empty()) {
-                LOG(LOG_LEVEL_WARNING, "POLLHUP bit set; closing connection");
-                break;
-            }
+            0,
+            nullptr
+        });
+
+        {
+            std::unique_lock<std::shared_mutex> _lock(_readTasksMutex);
+            _readTasks.emplace(readTask);
         }
 
-        if (pollFd.revents & POLLERR) {
-            LOG(LOG_LEVEL_ERROR, "POLLERR bit set; closing connection");
-            break;
+        auto future = readTask->promise->get_future();
+        auto retval = future.get();
+
+        return std::move(retval);
+    }
+
+    void IPCConnection::writeBlock(const void *pointer, size_t size) {
+        assert(pointer != nullptr);
+        assert(size > 0);
+
+        auto writeTask = std::make_shared<IPCWriteTask>(IPCWriteTask {
+                size,
+                std::shared_ptr<uint8_t>((uint8_t *) malloc(size), free)
+        });
+
+        memcpy(writeTask->data.get(), pointer, size);
+
+        {
+            _writeTasks.emplace(std::move(writeTask));
         }
     }
 
-    _isGood = false;
+    std::shared_ptr<ULIPCHeader> IPCConnection::nextHeader() {
+        auto header = std::move(this->readBlock<ULIPCHeader>(sizeof(ULIPCHeader)));
+
+        _ackId = header->id;
+        // TODO: check timestamp or std::max(_ackId, header->id)
+
+        return std::move(header);
+    }
 }

--- a/IPCConnection.template.cpp
+++ b/IPCConnection.template.cpp
@@ -1,0 +1,43 @@
+//
+// Created by Gyuhwan Park on 10/29/23.
+//
+
+#ifndef ULALACA_IPCCONNECTION_TEMPLATE_HPP
+#define ULALACA_IPCCONNECTION_TEMPLATE_HPP
+
+#include "IPCConnection.hpp"
+
+namespace ulalaca::ipc {
+    template <typename T>
+    std::shared_ptr<T> IPCConnection::readBlock(size_t size) {
+        auto dataBlock = this->readBlock(size);
+
+        return std::reinterpret_pointer_cast<T>(dataBlock);
+    }
+
+    template <typename T>
+    void IPCConnection::writeMessage(const ULIPCHeader &header, const T &message) {
+        std::unique_lock<std::shared_mutex> lock(_writeTasksMutex);
+
+        auto _header = header;
+        _header.id = _messageId++;
+        _header.length = sizeof(message);
+        // _header.timestamp = now();
+
+        writeBlock(&_header, sizeof(_header));
+        writeBlock(&message, sizeof(message));
+    }
+
+    template<typename T>
+    void IPCConnection::writeMessage(uint16_t messageType, const T &message) {
+        ULIPCHeader header {
+            messageType,
+            0,
+            0,
+            0,
+            sizeof(message)
+        };
+        writeMessage(header, message);
+    }
+}
+#endif

--- a/IPCConnection.workerloop.cpp
+++ b/IPCConnection.workerloop.cpp
@@ -1,0 +1,129 @@
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
+#include <cassert>
+#include <utility>
+
+#include <fcntl.h>
+
+extern "C" {
+#include "parse.h"
+#include "defines.h"
+}
+
+#include "IPCConnection.hpp"
+
+namespace ulalaca::ipc {
+
+    void IPCConnection::workerLoop() {
+        const size_t MAX_RW_SIZE = 8192;
+
+        const auto isWriteQueueEmpty = [this] {
+            std::shared_lock<std::shared_mutex> _lock(_writeTasksMutex);
+            return _writeTasks.empty();
+        };
+
+        const auto nextWriteTask = [this] {
+            std::shared_lock<std::shared_mutex> _lock(_writeTasksMutex);
+            auto writeTask = _writeTasks.front();
+            return writeTask;
+        };
+
+        const auto popWriteTask = [this] {
+            std::unique_lock<std::shared_mutex> _lock(_writeTasksMutex);
+            _writeTasks.pop();
+        };
+
+        const auto isReadQueueEmpty = [this] {
+            std::shared_lock<std::shared_mutex> _lock(_readTasksMutex);
+            return _readTasks.empty();
+        };
+
+        const auto nextReadTask = [this] {
+            std::shared_lock<std::shared_mutex> _lock(_readTasksMutex);
+            auto readTask = _readTasks.front();
+            return readTask;
+        };
+
+        const auto popReadTask = [this] {
+            std::unique_lock<std::shared_mutex> _lock(_readTasksMutex);
+            _readTasks.pop();
+        };
+
+        _isGood = true;
+
+        while (!_isWorkerTerminated) {
+            const auto pollFd = _socket->poll(POLLIN | POLLOUT, -1);
+
+            const bool canRead = (pollFd.revents & POLLIN) > 0;
+            const bool canWrite = (pollFd.revents & POLLOUT) > 0;
+
+            if (canWrite && !isWriteQueueEmpty()) {
+                auto writeTask = nextWriteTask();
+
+                if (_socket->write(writeTask->data.get(), writeTask->size) < 0) {
+                    LOG(LOG_LEVEL_ERROR, "write() failed (errno=%d)", errno);
+                } else {
+                    popWriteTask();
+                }
+            }
+
+            if (canRead && !isReadQueueEmpty()) {
+                auto readTask = nextReadTask();
+
+                auto &size = readTask->size;
+                auto &buffer = readTask->buffer;
+                auto &read = readTask->read;
+                auto &promise = readTask->promise;
+
+                if (buffer == nullptr) {
+                    read = 0;
+                    buffer = std::shared_ptr<uint8_t>((uint8_t *) malloc(size), free);
+                }
+
+                size_t bytesToRead = std::min(
+                    (size_t) MAX_RW_SIZE,
+                    size - read
+                );
+
+                ssize_t retval = _socket->read(buffer.get() + read, bytesToRead);
+
+                if (retval <= 0) {
+                    if (errno != EAGAIN) {
+                        LOG(LOG_LEVEL_ERROR, "read() failed (errno=%d)", errno);
+                        _isGood = false;
+                        break;
+                    }
+                }
+
+
+                read += retval;
+
+                if (read >= size) {
+                    popReadTask();
+                    promise->set_value(std::move(buffer));
+
+                    buffer = nullptr;
+                }
+            }
+
+            if (pollFd.revents & POLLHUP) {
+                LOG(LOG_LEVEL_INFO, "POLLHUP bit set");
+                _isGood = false;
+
+                if (isReadQueueEmpty() || !canRead) {
+                    LOG(LOG_LEVEL_INFO, "POLLHUP bit set; closing connection");
+                    break;
+                }
+            }
+
+            if (pollFd.revents & POLLERR) {
+                LOG(LOG_LEVEL_ERROR, "POLLERR bit set; closing connection");
+                break;
+            }
+        }
+
+        _isGood = false;
+    }
+}

--- a/Makefile.am
+++ b/Makefile.am
@@ -27,6 +27,7 @@ libulalaca_la_SOURCES = \
   UlalacaMessages.hpp \
   IPCConnection.hpp \
   IPCConnection.cpp \
+  IPCConnection.workerloop.cpp \
   SessionBrokerClient.hpp \
   SessionBrokerClient.cpp \
   ProjectorClient.hpp \

--- a/ProjectorClient.cpp
+++ b/ProjectorClient.cpp
@@ -215,17 +215,17 @@ void ProjectorClient::mainLoop() {
         
         switch (header->messageType) {
             case TYPE_SCREEN_UPDATE_NOTIFY: {
-                auto notification = _ipcConnection.read<ULIPCScreenUpdateNotify>(header->length);
+                auto notification = _ipcConnection.readBlock<ULIPCScreenUpdateNotify>(header->length);
     
                 LOG(LOG_LEVEL_DEBUG, "mainLoop(): adding dirty rect");
                 _target.addDirtyRect(notification->rect);
                 continue;
             }
             case TYPE_SCREEN_UPDATE_COMMIT: {
-                auto commit = _ipcConnection.read<ULIPCScreenUpdateCommit>(header->length);
-                auto bitmap = _ipcConnection.read<uint8_t>(commit->bitmapLength);
+                auto commit = _ipcConnection.readBlock<ULIPCScreenUpdateCommit>(header->length);
+                auto bitmap = _ipcConnection.readBlock<uint8_t>(commit->bitmapLength);
     
-                LOG(LOG_LEVEL_DEBUG, "mainLoop(): commiting update");
+                LOG(LOG_LEVEL_DEBUG, "mainLoop(): commit update");
                 _target.commitUpdate(
                     bitmap.get(),
                     commit->bitmapLength,
@@ -236,7 +236,7 @@ void ProjectorClient::mainLoop() {
             }
             default: {
                 // ignore
-                _ipcConnection.read<uint8_t>(header->length);
+                _ipcConnection.readBlock<uint8_t>(header->length);
             }
         }
     }

--- a/ProjectorClient.hpp
+++ b/ProjectorClient.hpp
@@ -17,7 +17,6 @@
 
 #include "ProjectionTarget.hpp"
 
-
 class ProjectorClient {
 public:
     explicit ProjectorClient(
@@ -34,7 +33,7 @@ public:
     void sendHello(const std::string &xrdpUlalacaVersion, const xrdp_client_info &clientInfo);
     void handleEvent(XrdpEvent &event);
     void setViewport(ULIPCRect rect);
-    
+
     void setOutputSuppression(bool isOutputSuppressed);
 
 private:
@@ -42,7 +41,7 @@ private:
 
     ProjectionTarget &_target;
     IPCConnection _ipcConnection;
-    
+
     bool _isTerminated;
     std::thread _projectorThread;
 };

--- a/SessionBrokerClient.cpp
+++ b/SessionBrokerClient.cpp
@@ -50,7 +50,7 @@ SessionBrokerResponse SessionBrokerClient::requestSession(const std::string &use
 
         switch (responseHeader->messageType) {
             case TYPE_SESSION_REQUEST_RESOLVED: {
-                auto body = connection.read<ULIPCSessionRequestResolved>(
+                auto body = connection.readBlock<ULIPCSessionRequestResolved>(
                     sizeof(ULIPCSessionRequestResolved)
                 );
 
@@ -63,7 +63,7 @@ SessionBrokerResponse SessionBrokerClient::requestSession(const std::string &use
                 break;
 
             case TYPE_SESSION_REQUEST_REJECTED: {
-                auto body = connection.read<ULIPCSessionRequestRejected>(
+                auto body = connection.readBlock<ULIPCSessionRequestRejected>(
                         sizeof(ULIPCSessionRequestRejected)
                 );
 

--- a/UnixSocket.cpp
+++ b/UnixSocket.cpp
@@ -20,115 +20,116 @@
 
 #include "UnixSocket.hpp"
 
-ssize_t UnixSocketBase::read(void *buffer, size_t size) {
-    return ::read(descriptor(), buffer, size);
-}
+namespace ulalaca::ipc {
 
-ssize_t UnixSocketBase::write(const void *buffer, size_t size) {
-    return ::write(descriptor(), buffer, size);
-}
-
-pollfd UnixSocketBase::poll(short events, int timeout) {
-    pollfd pollFd = {
-        descriptor(),
-        events,
-        0
-    };
-
-    if (::poll(&pollFd, 1, timeout) < 0) {
-        throw SystemCallException(errno, "poll");
+    ssize_t UnixSocketBase::read(void *buffer, size_t size) {
+        return ::read(descriptor(), buffer, size);
     }
 
-    return pollFd;
-}
+    ssize_t UnixSocketBase::write(const void *buffer, size_t size) {
+        return ::write(descriptor(), buffer, size);
+    }
 
-int UnixSocketBase::fcntl(int cmd, int arg) {
-    return ::fcntl(descriptor(), cmd, arg);
-}
+    pollfd UnixSocketBase::poll(short events, int timeout) {
+        pollfd pollFd = {
+                descriptor(),
+                events,
+                0
+        };
 
-void UnixSocketBase::close() {
-    ::close(descriptor());
-}
-
-UnixSocketConnection::UnixSocketConnection(FD descriptor, sockaddr_un clientAddress) :
-        _descriptor(descriptor),
-        _clientAddress(clientAddress)
-{
-}
-
-FD UnixSocketConnection::descriptor() {
-    return _descriptor;
-}
-
-
-UnixSocket::UnixSocket(const std::string path):
-        _path(path),
-        _descriptor(createSocket())
-{
-}
-
-void UnixSocket::bind() {
-    if (std::filesystem::exists(_path)) {
-        if (!std::filesystem::is_socket(_path)) {
-            // TODO: file exists, but not socket
-            throw std::runtime_error("");
+        if (::poll(&pollFd, 1, timeout) < 0) {
+            throw SystemCallException(errno, "poll");
         }
 
-        std::filesystem::remove(_path);
+        return pollFd;
     }
 
-    sockaddr_un address = {};
-    address.sun_family = AF_UNIX;
-    std::strncpy(address.sun_path, _path.c_str(), _path.size());
-
-    int retval = ::bind(_descriptor, (sockaddr *) &address, sizeof(address));
-    if (retval == -1) {
-        throw SystemCallException(errno, "bind");
-    }
-}
-
-void UnixSocket::listen() {
-    int retval = ::listen(_descriptor, 0);
-    if (retval == -1) {
-        throw SystemCallException(errno, "listen");
-    }
-}
-
-UnixSocketConnection UnixSocket::accept() {
-    socklen_t addressLength = 0;
-    sockaddr_un clientAddress = {};
-    FD client = ::accept(_descriptor, (sockaddr *) &clientAddress, &addressLength);
-
-    if (client == -1) {
-        throw SystemCallException(errno, "accept");
+    int UnixSocketBase::fcntl(int cmd, int arg) {
+        return ::fcntl(descriptor(), cmd, arg);
     }
 
-    // assert(addressLength == sizeof(clientAddress));
-
-    return UnixSocketConnection(client, clientAddress);
-}
-
-void UnixSocket::connect() {
-    sockaddr_un address = {};
-    address.sun_family = AF_UNIX;
-    std::strncpy(address.sun_path, _path.c_str(), _path.size());
-    address.sun_len = _path.size();
-
-    int retval = ::connect(_descriptor, (sockaddr *) &address, sizeof(address));
-    if (retval < 0) {
-        throw SystemCallException(errno, "connect");
+    void UnixSocketBase::close() {
+        ::close(descriptor());
     }
-}
 
-FD UnixSocket::descriptor() {
-    return _descriptor;
-}
-
-FD UnixSocket::createSocket() {
-    FD descriptor = socket(AF_UNIX, SOCK_STREAM, 0);
-
-    if (descriptor < 0) {
-        throw SystemCallException(errno, "socket");
+    UnixSocketConnection::UnixSocketConnection(FD descriptor, sockaddr_un clientAddress) :
+            _descriptor(descriptor),
+            _clientAddress(clientAddress) {
     }
-    return descriptor;
+
+    FD UnixSocketConnection::descriptor() {
+        return _descriptor;
+    }
+
+
+    UnixSocket::UnixSocket(const std::string path) :
+            _path(path),
+            _descriptor(createSocket()) {
+    }
+
+    void UnixSocket::bind() {
+        if (std::filesystem::exists(_path)) {
+            if (!std::filesystem::is_socket(_path)) {
+                // TODO: file exists, but not socket
+                throw std::runtime_error("");
+            }
+
+            std::filesystem::remove(_path);
+        }
+
+        sockaddr_un address = {};
+        address.sun_family = AF_UNIX;
+        std::strncpy(address.sun_path, _path.c_str(), _path.size());
+
+        int retval = ::bind(_descriptor, (sockaddr *) &address, sizeof(address));
+        if (retval == -1) {
+            throw SystemCallException(errno, "bind");
+        }
+    }
+
+    void UnixSocket::listen() {
+        int retval = ::listen(_descriptor, 0);
+        if (retval == -1) {
+            throw SystemCallException(errno, "listen");
+        }
+    }
+
+    UnixSocketConnection UnixSocket::accept() {
+        socklen_t addressLength = 0;
+        sockaddr_un clientAddress = {};
+        FD client = ::accept(_descriptor, (sockaddr *) &clientAddress, &addressLength);
+
+        if (client == -1) {
+            throw SystemCallException(errno, "accept");
+        }
+
+        // assert(addressLength == sizeof(clientAddress));
+
+        return UnixSocketConnection(client, clientAddress);
+    }
+
+    void UnixSocket::connect() {
+        sockaddr_un address = {};
+        address.sun_family = AF_UNIX;
+        std::strncpy(address.sun_path, _path.c_str(), _path.size());
+        address.sun_len = _path.size();
+
+        int retval = ::connect(_descriptor, (sockaddr *) &address, sizeof(address));
+        if (retval < 0) {
+            throw SystemCallException(errno, "connect");
+        }
+    }
+
+    FD UnixSocket::descriptor() {
+        return _descriptor;
+    }
+
+    FD UnixSocket::createSocket() {
+        FD descriptor = socket(AF_UNIX, SOCK_STREAM, 0);
+
+        if (descriptor < 0) {
+            throw SystemCallException(errno, "socket");
+        }
+        return descriptor;
+    }
 }

--- a/UnixSocket.hpp
+++ b/UnixSocket.hpp
@@ -16,104 +16,122 @@
 
 using FD = int;
 
-class UnixSocketBase {
-public:
+namespace ulalaca::ipc {
 
-    /**
-     * 파일 디스크립터를 반환합니다.
-     *
-     * @note 임의로 닫지 마십시오.
-     */
-    virtual FD descriptor() = 0;
+    class UnixSocketBase {
+    public:
 
-    /**
-     * 소켓으로부터 데이터를 읽습니다.
-     *
-     * @param buffer 입력 버퍼
-     * @param size 읽고자 하는 데이터의 크기
-     *
-     * @return 버퍼에 실제로 읽힌 데이터의 크기를 반환합니다.
-     *         플랫폼에 따라 오류가 발생하면 음수 값이 반환될 수 있습니다.
-     */
-    virtual ssize_t read(void *buffer, size_t size);
+        /**
+         * 파일 디스크립터를 반환합니다.
+         *
+         * @note 임의로 닫지 마십시오.
+         */
+        virtual FD descriptor() = 0;
 
-    /**
-     * 소켓에 데이터를 씁니다.
-     *
-     * @param buffer 출력 버퍼
-     * @param size 쓰고자 하는 데이터의 크기
-     *
-     * @return 소켓에 실제로 쓰여진 데이터의 크기를 반환합니다.
-     *         플랫폼에 따라 오류가 발생하면 음수 값이 반환될 수 있습니다.
-     */
-    virtual ssize_t write(const void *buffer, size_t size);
+        /**
+         * 소켓으로부터 데이터를 읽습니다.
+         *
+         * @param buffer 입력 버퍼
+         * @param size 읽고자 하는 데이터의 크기
+         *
+         * @return 버퍼에 실제로 읽힌 데이터의 크기를 반환합니다.
+         *         플랫폼에 따라 오류가 발생하면 음수 값이 반환될 수 있습니다.
+         */
+        virtual ssize_t read(void *buffer, size_t size);
 
-    virtual pollfd poll(short events, int timeout);
-    virtual int fcntl(int cmd, int arg);
+        /**
+         * 소켓에 데이터를 씁니다.
+         *
+         * @param buffer 출력 버퍼
+         * @param size 쓰고자 하는 데이터의 크기
+         *
+         * @return 소켓에 실제로 쓰여진 데이터의 크기를 반환합니다.
+         *         플랫폼에 따라 오류가 발생하면 음수 값이 반환될 수 있습니다.
+         */
+        virtual ssize_t write(const void *buffer, size_t size);
 
-    /**
-     * 소켓을 닫습니다.
-     */
-    virtual void close();
+        virtual pollfd poll(short events, int timeout);
 
-};
+        virtual int fcntl(int cmd, int arg);
 
-class UnixSocketConnection: public UnixSocketBase {
-public:
-    explicit UnixSocketConnection(FD descriptor, sockaddr_un clientAddress);
+        /**
+         * 소켓을 닫습니다.
+         */
+        virtual void close();
 
-    FD descriptor() override;
+    };
 
-private:
-    FD _descriptor;
-    sockaddr_un _clientAddress;
-};
+    class UnixSocketConnection : public UnixSocketBase {
+    public:
+        explicit UnixSocketConnection(FD descriptor, sockaddr_un clientAddress);
 
-class UnixSocket: public UnixSocketBase {
-public:
-    explicit UnixSocket(const std::string path);
+        FD descriptor() override;
 
-    /**
-     * bind(2)를 호출합니다.
-     *
-     * @see man 2 bind
-     * @throws SystemCallException
-     *      bind()의 리턴 값이 -1일 시 errno를 담은 예외를 던집니다.
-     */
-    virtual void bind();
+    private:
+        FD _descriptor;
+        sockaddr_un _clientAddress;
+    };
 
-    /**
-     * listen(2)를 호출합니다.
-     *
-     * @see man 2 listen
-     * @throws SystemCallException
-     *      listen()의 리턴 값이 -1일 시 errno를 담은 예외를 던집니다.
-     */
-    virtual void listen();
+    class UnixSocket : public UnixSocketBase {
+    public:
+        explicit UnixSocket(const std::string path);
 
-    /**
-     * accept(2)를 호출합니다.
-     *
-     * @see man 2 accept
-     * @return (File Descriptor, sockaddr_un)의 pair를 반환합니다.
-     * @throws SystemCallException
-     *      accept()의 리턴 값이 -1일 시 errno를 담은 예외를 던집니다.
-     */
-    virtual UnixSocketConnection accept();
+        /**
+         * bind(2)를 호출합니다.
+         *
+         * @see man 2 bind
+         * @throws SystemCallException
+         *      bind()의 리턴 값이 -1일 시 errno를 담은 예외를 던집니다.
+         */
+        virtual void bind();
 
-    /**
-     * connect(2)를 호출합니다.
-     */
-    virtual void connect();
+        /**
+         * listen(2)를 호출합니다.
+         *
+         * @see man 2 listen
+         * @throws SystemCallException
+         *      listen()의 리턴 값이 -1일 시 errno를 담은 예외를 던집니다.
+         */
+        virtual void listen();
 
-    FD descriptor() override;
+        /**
+         * accept(2)를 호출합니다.
+         *
+         * @see man 2 accept
+         * @return (File Descriptor, sockaddr_un)의 pair를 반환합니다.
+         * @throws SystemCallException
+         *      accept()의 리턴 값이 -1일 시 errno를 담은 예외를 던집니다.
+         */
+        virtual UnixSocketConnection accept();
 
-    static FD createSocket();
-private:
-    std::string _path;
-    FD _descriptor;
-};
+        /**
+         * connect(2)를 호출합니다.
+         */
+        virtual void connect();
 
+        FD descriptor() override;
+
+        static FD createSocket();
+
+    private:
+        std::string _path;
+        FD _descriptor;
+    };
+
+}
+
+/**
+ * @deprecated Use ulalaca::ipc::UnixSocketBase instead.
+ */
+using UnixSocketBase = ulalaca::ipc::UnixSocketBase;
+/**
+ * @deprecated Use ulalaca::ipc::UnixSocket instead.
+ */
+using UnixSocket = ulalaca::ipc::UnixSocket;
+/**
+ * @deprecated Use ulalaca::ipc::UnixSocketConnection instead.
+ */
+using UnixSocketConnection = ulalaca::ipc::UnixSocketConnection;
 
 
 

--- a/XrdpUlalacaPrivate.cpp
+++ b/XrdpUlalacaPrivate.cpp
@@ -151,7 +151,15 @@ void XrdpUlalacaPrivate::updateThreadLoop() {
         try {
             _surface->beginUpdate();
             if (!_surface->submitUpdate(*transaction)) {
-                // log("frame dropped");
+                LOG(LOG_LEVEL_INFO, "frame dropped");
+
+                // clear queue
+                {
+                    std::unique_lock<std::mutex> lock(_updateQueueMutex);
+                    while (!_updateQueue.empty()) {
+                        _updateQueue.pop();
+                    }
+                }
             }
             _surface->endUpdate();
         } catch (ulalaca::ULSurfaceException &e) {


### PR DESCRIPTION
# SUMMARY
- **This PR may contain breaking changes**

## CHANGES / TODO
- I/O loop in IPCConnection will be reimplemented
- IPC-related classes (IPCConnection, UnixSocket, etc.) will moved into the `ulalaca::ipc` namespace.
- #2 를 완전히 해결하는 것을 목표로 하고 있습니다 
